### PR TITLE
Allow indexing without fully allocating array

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.3.1"
 
 [deps]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+IterTools = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
 LabelledArrays = "2ee39098-c373-598a-b85f-a56591580800"
 Yields = "d7e99b2f-e7f3-4d9e-9f01-2338fc023ad3"
 

--- a/src/EconomicScenarioGenerators.jl
+++ b/src/EconomicScenarioGenerators.jl
@@ -2,6 +2,7 @@ module EconomicScenarioGenerators
 
 import ForwardDiff
 import Yields
+import IterTools
 
 using LabelledArrays
 
@@ -49,6 +50,15 @@ end
 
 function Base.eachindex(sg::ScenarioGenerator{N,T}) where {N,T<:EconomicModel}
     return Base.OneTo(length(sg))
+end
+
+
+function Base.getindex(sg::ScenarioGenerator{N,T},i) where {N,T<:EconomicModel}
+    return IterTools.nth(sg,i)
+end
+
+function Base.lastindex(sg::ScenarioGenerator{N,T}) where {N,T<:EconomicModel}
+    return length(sg)
 end
 
 Base.eltype(::Type{ScenarioGenerator{N,T}}) where {N,T} = outputtype(T)

--- a/test/generator.jl
+++ b/test/generator.jl
@@ -1,0 +1,11 @@
+@testset "indexing" begin
+    m = BlackScholesMerton(0.01,0.00,.15,100.)
+    s = ScenarioGenerator(
+        1/252,  # timestep
+        1., # projection horizon
+        m,  # model
+    ) 
+    @test last(s) isa Real
+    @test first(s) isa Real
+    @test s[10] isa Real
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,3 +7,4 @@ using HypothesisTests
 include("utils.jl")
 include("interest.jl")
 include("equity.jl")
+include("generator.jl")


### PR DESCRIPTION
Most of the time is still spent actually running the iterator, but it's more memory efficient for the last value and is more time-efficient if interested in an intermediate timestep:

Without this PR:

```julia-repl
julia> @btime collect($s)[end]
  2.727 μs (6 allocations: 2.30 KiB)
```

With this PR:
```julia-repl
julia> @btime last($s)
  2.690 μs (5 allocations: 176 bytes)

julia> @btime $s[5]
  382.591 ns (5 allocations: 176 bytes)
```

Note that you cannot recover the same RNG with subsequent indexing operations, but this can be achieved by `collecting` the iterator for the full stream.

