### PR TITLE
reduce heap allocations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,14 +6,12 @@ version = "0.3.4"
 [deps]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 IterTools = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
-LabelledArrays = "2ee39098-c373-598a-b85f-a56591580800"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Yields = "d7e99b2f-e7f3-4d9e-9f01-2338fc023ad3"
 
 [compat]
 ForwardDiff = "^0.10"
 IterTools = "^1.4"
-LabelledArrays = "^1"
 Yields = "^3"
 julia = "1.6"
 

--- a/README.md
+++ b/README.md
@@ -193,14 +193,16 @@ p
 
 ## Benchmarks
 
-Generating 10,000 daily timesteps for 1 year (252 business days) with a Black-Scholes-Merton model:
+Generating 10,000 scenarios of daily timesteps for 1 year (252 business days) with a Black-Scholes-Merton model:
 
 
-| library                    | multi-threaded? | language | time (absolute) | time (relative) |
-|----------------------------|----------|----------|-----------------|-----------------|
-| EconomicScenarioGenerators | Yes    | Julia    | 12ms          | 1x              |
-| EconomicScenarioGenerators | No    | Julia    | 40ms          | 4x              |
-| pyesg                      | No?   | Python   | 135ms           | 11x              |
+| library                    | multi-threaded? | pre-allocated arrays? |  language | time (absolute) | time (relative) |
+|----------------------------|-----------------|-----------------------|-----------------|-----------------|---------|
+| EconomicScenarioGenerators | 8x    |Yes | Julia    | 6ms          | 1x              |
+| EconomicScenarioGenerators | 8x    |No | Julia    | 12ms          | 2x              |
+| EconomicScenarioGenerators | No    |Yes | Julia    | 19ms          | 3x              |
+| EconomicScenarioGenerators | No    |No | Julia    | 40ms          | 7x              |
+| pyesg                      | No?   |No | Python   | 135ms           | 22x              |
 
 ## Other ESG packages
 

--- a/src/EconomicScenarioGenerators.jl
+++ b/src/EconomicScenarioGenerators.jl
@@ -5,8 +5,6 @@ import Yields
 import IterTools
 using Random
 
-using LabelledArrays
-
 abstract type EconomicModel end
 
 function initial_value(m::T) where {T<:EconomicModel}
@@ -39,18 +37,20 @@ end
 
 function Base.iterate(sg::ScenarioGenerator{N,T,R}) where {N,T<:EconomicModel,R}
     initial = initial_value(sg.model,sg.timestep)
-    state = @LArray [0,initial] (:time,:rate)
-    return (state.rate,state) # TODO: Implement intitial conditions for models
+    state = (time=zero(sg.timestep),value=initial)
+    return (state.value,state) # TODO: Implement intitial conditions for models
 end
 
 function Base.iterate(sg::ScenarioGenerator{N,T,R},state) where {N,T<:EconomicModel,R}
     if (state.time > sg.endtime) || (state.time ≈ sg.endtime)
         return nothing
     else
-        new_rate = nextrate(sg.RNG,sg.model,state.rate,state.time,sg.timestep)
-        state.time += sg.timestep
-        state.rate = new_rate
-        return (state.rate, state)
+        new_rate = nextrate(sg.RNG,sg.model,state.value,state.time,sg.timestep)
+        state = (
+            time = state.time + sg.timestep,
+            value = new_rate
+        )
+        return (state.value, state)
     end
 end
 


### PR DESCRIPTION
closes #27 

Labelled arrays was allocating itself - a named tuple is simpler and remains on the stack