### PR TITLE
add type annotations to improve type inference

### DIFF
--- a/src/EconomicScenarioGenerators.jl
+++ b/src/EconomicScenarioGenerators.jl
@@ -37,7 +37,7 @@ end
 
 function Base.iterate(sg::ScenarioGenerator{N,T,R}) where {N,T<:EconomicModel,R}
     initial = initial_value(sg.model,sg.timestep)
-    state = (time=zero(sg.timestep),value=initial)
+    state = (time=zero(sg.timestep)::N,value=initial)
     return (state.value,state) # TODO: Implement intitial conditions for models
 end
 

--- a/src/Yields.jl
+++ b/src/Yields.jl
@@ -12,6 +12,8 @@ function __zeros_times(sg::ScenarioGenerator{N,T,R}) where {N,T<:InterestRateMod
     times = sg.timestep:sg.timestep:(sg.endtime+sg.timestep)
     # compute the accumulated discount factor (ZCB price)
     zeros = cumsum(sg .* sg.timestep) ./ times
+    # the broadcasting versions is about 1/3 fewer allocations
+    # zeros = Iterators.map(/,Iterators.accumulate(+,sg),times)
 
     return zeros, times
 end

--- a/src/interest.jl
+++ b/src/interest.jl
@@ -170,8 +170,8 @@ function θ(M::HullWhite{T},time,timestep) where {T<:Yields.AbstractYield}
     # https://mdpi-res.com/d_attachment/mathematics/mathematics-08-01719/article_deploy/mathematics-08-01719-v2.pdf?version=1603181408
     a = M.a
     f(t) = log(Yields.discount(M.curve,t[1]))
-    δf = -only(ForwardDiff.hessian(f,[time])) 
-    f_t = -only(ForwardDiff.gradient(f,[time]))
+    δf = -only(ForwardDiff.hessian(f,[time]))::Float64 
+    f_t = -only(ForwardDiff.gradient(f,[time]))::Float64
 
     return δf + f_t * a  + M.σ^2 / (2*a)*(1-exp(-2*a*time))
 


### PR DESCRIPTION
Before:
```julia-repl
julia> @btime YieldCurve(s)
  1.008 ms (12965 allocations: 473.88 KiB)
```
After:
```julia-repl
julia> @btime YieldCurve(s)
  772.417 μs (6061 allocations: 337.81 KiB)
```