### PR TITLE
Update doc links to docs.juliaactuary.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # EconomicScenarioGenerators.jl
 
-[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://JuliaActuary.github.io/EconomicScenarioGenerators.jl/stable)
-[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://JuliaActuary.github.io/EconomicScenarioGenerators.jl/dev)
+[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://docs.juliaactuary.org/EconomicScenarioGenerators/stable/)
+[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://docs.juliaactuary.org/EconomicScenarioGenerators/dev/)
 [![Build Status](https://github.com/JuliaActuary/EconomicScenarioGenerators.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/JuliaActuary/EconomicScenarioGenerators.jl/actions/workflows/CI.yml?query=branch%3Amain)
 [![Coverage](https://codecov.io/gh/JuliaActuary/EconomicScenarioGenerators.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/JuliaActuary/EconomicScenarioGenerators.jl)
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -10,7 +10,7 @@ makedocs(;
     sitename="EconomicScenarioGenerators.jl",
     format=Documenter.HTML(;
         prettyurls=get(ENV, "CI", "false") == "true",
-        canonical="https://JuliaActuary.github.io/EconomicScenarioGenerators.jl",
+        canonical="https://docs.juliaactuary.org/EconomicScenarioGenerators",
         assets=String[],
     ),
     pages=[

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -3,8 +3,8 @@ CurrentModule = EconomicScenarioGenerators
 ```
 # EconomicScenarioGenerators.jl
 
-[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://JuliaActuary.github.io/EconomicScenarioGenerators.jl/stable)
-[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://JuliaActuary.github.io/EconomicScenarioGenerators.jl/dev)
+[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://docs.juliaactuary.org/EconomicScenarioGenerators/stable/)
+[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://docs.juliaactuary.org/EconomicScenarioGenerators/dev/)
 [![Build Status](https://github.com/JuliaActuary/EconomicScenarioGenerators.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/JuliaActuary/EconomicScenarioGenerators.jl/actions/workflows/CI.yml?query=branch%3Amain)
 [![Coverage](https://codecov.io/gh/JuliaActuary/EconomicScenarioGenerators.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/JuliaActuary/EconomicScenarioGenerators.jl)
 


### PR DESCRIPTION
## Summary
- Update documentation badge links in README and docs index to point to the unified `docs.juliaactuary.org` site instead of `JuliaActuary.github.io`
- Update canonical URL in `docs/make.jl` to reflect the new docs site

## Test plan
- [ ] Verify badge links resolve correctly to `https://docs.juliaactuary.org/EconomicScenarioGenerators/stable/` and `/dev/`
- [ ] Verify docs build succeeds with updated canonical URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)